### PR TITLE
fix: HackRF support in radio engine (sample rate + DC spike)

### DIFF
--- a/engine/meshtastic_engine/flowgraphs/rx_lora_base_engine.py
+++ b/engine/meshtastic_engine/flowgraphs/rx_lora_base_engine.py
@@ -61,6 +61,29 @@ class rx_lora_base_engine(gr.top_block):
         samp_rate = int(samp_rate)
         lora_bw = int(lora_bw)
         sync_word = [int(x) for x in sync_word]
+
+        # --- HackRF-specific workarounds ---
+        # HackRF is a direct-conversion (zero-IF) receiver with two quirks
+        # that break LoRa decoding when the flowgraph is tuned for RTL-SDR:
+        #
+        # 1. Minimum sample rate: HackRF hardware ignores requests below
+        #    2 Msps and silently clocks at 2 Msps regardless. GNU Radio
+        #    then believes it is operating at the requested (lower) rate,
+        #    so every FFT window and chip-timing calculation is wrong,
+        #    causing 100 % CRC failure. Fix: enforce 2 Msps minimum.
+        #
+        # 2. DC spike: direct-conversion mixers produce a strong DC
+        #    component at the exact tuned frequency. LoRa chirps sweep
+        #    through 0 Hz on every symbol, so the spike corrupts the FFT
+        #    bin at the centre of each chirp. Fix: offset-tune the hardware
+        #    500 kHz above the target and compensate in the freq_xlating
+        #    filter so the DC spike falls outside the LoRa passband.
+        is_hackrf = "hackrf" in str(device_args).lower()
+        if is_hackrf:
+            samp_rate = max(samp_rate, 2_000_000)
+            dc_shift = 500_000
+        else:
+            dc_shift = 0
         self.sync_word = sync_word
         self.soft_decoding = soft_decoding = True
         sf = int(sf)
@@ -88,10 +111,13 @@ class rx_lora_base_engine(gr.top_block):
         self.rtlsdr_source_0.set_time_source('external', 0)
         self.rtlsdr_source_0.set_time_unknown_pps(osmosdr.time_spec_t())
         self.rtlsdr_source_0.set_sample_rate(samp_rate)
-        self.rtlsdr_source_0.set_center_freq(center_freq, 0)
+        self.rtlsdr_source_0.set_center_freq(center_freq + dc_shift, 0)
         self.rtlsdr_source_0.set_freq_corr(ppm, 0)
-        self.rtlsdr_source_0.set_dc_offset_mode(0, 0)
-        self.rtlsdr_source_0.set_iq_balance_mode(0, 0)
+        # HackRF benefits from automatic software DC/IQ correction;
+        # leave RTL-SDR at its original settings (mode 0).
+        dc_iq_mode = 2 if is_hackrf else 0
+        self.rtlsdr_source_0.set_dc_offset_mode(dc_iq_mode, 0)
+        self.rtlsdr_source_0.set_iq_balance_mode(dc_iq_mode, 0)
         self.rtlsdr_source_0.set_gain_mode(False, 0)
         self.rtlsdr_source_0.set_gain(gain, 0)
         self.rtlsdr_source_0.set_if_gain(int(if_gain), 0)
@@ -107,7 +133,7 @@ class rx_lora_base_engine(gr.top_block):
         self.lora_sdr_dewhitening_0_1 = lora_sdr.dewhitening()
         self.lora_sdr_deinterleaver_0_1 = lora_sdr.deinterleaver( soft_decoding)
         self.lora_sdr_crc_verif_0_1 = lora_sdr.crc_verif( 2, False)
-        self.freq_xlating_fir_filter_xxx_0 = filter.freq_xlating_fir_filter_ccc((max(1, int(samp_rate/(lora_bw * 4)))), bandpass250k, 0, samp_rate)
+        self.freq_xlating_fir_filter_xxx_0 = filter.freq_xlating_fir_filter_ccc((max(1, int(samp_rate/(lora_bw * 4)))), bandpass250k, -dc_shift, samp_rate)
         self.freq_xlating_fir_filter_xxx_0.set_min_output_buffer(17000)
         self.epy_block_2 = epy_block_2.blk()
         self.epy_block_1 = epy_block_1.blk()


### PR DESCRIPTION
## Problem

The internal radio engine was designed for RTL-SDR. Two hardware differences in HackRF cause **100% CRC failure** out of the box when using HackRF as the receiver.

## Fix 1 — Sample rate floor

HackRF ignores any sample rate request below 2 Msps and silently operates at 2 Msps regardless. With the default 1 Msps preset, GNU Radio believes it is getting 1 Msps but receives 2 Msps worth of data. Every LoRa FFT window is computed against half the actual sample count, scrambling every symbol.

**Fix:** clamp `samp_rate` to 2 Msps minimum when HackRF is detected.

## Fix 2 — DC spike / offset tuning

HackRF is a direct-conversion (zero-IF) receiver. Its mixer produces a strong DC component at the exact tuned frequency. LoRa chirps sweep through 0 Hz on every symbol period, so this spike corrupts the FFT bin at the chirp centre on every packet.

**Fix:** offset-tune the hardware 500 kHz above the target frequency and compensate with an equal negative shift in `freq_xlating_fir_filter`. The DC spike then lands 500 kHz outside the LoRa passband and has no effect on decoding.

## Compatibility

Both fixes are gated on `"hackrf" in device_args` — RTL-SDR and all other devices are completely unaffected.

## Test environment

- HackRF One r9 (firmware 2023.01.1)
- Raspberry Pi 5, aarch64
- GNU Radio 3.10.12, gr-osmosdr 0.2.6
- US 915 MHz, Long Fast preset (SF11, 250 kHz BW)
- Result: went from 100% CRC failure → packets decoding successfully